### PR TITLE
Feature/brian duplication bug

### DIFF
--- a/bin/sanger_workflow_decider.pl
+++ b/bin/sanger_workflow_decider.pl
@@ -47,14 +47,15 @@ my ($cluster_information, $running_sample_ids, $failed_samples, $completed_sampl
 
 #my $failed_db = Decider::Database->failed_connect();
 
-#print "CLUSTER INFO:\n";
-#print Dumper($cluster_information);
-#print "RUNNING SAMPLES:\n";
-#print Dumper($running_sample_ids);
-#print "FAILED SAMPLES:\n";
-#print Dumper($failed_samples);
-#print "COMPLETED SAMPLES:\n";
-#print Dumper($completed_samples);
+print "CLUSTER INFO:\n";
+print Dumper($cluster_information);
+print "RUNNING SAMPLES:\n";
+print Dumper($running_sample_ids);
+print "FAILED SAMPLES:\n";
+print Dumper($failed_samples);
+print "COMPLETED SAMPLES:\n";
+print Dumper($completed_samples);
+die;
 
 say 'Reading in GNOS Sample Information';
 my $gnos_info = GNOS::SampleInformation->new();

--- a/bin/sanger_workflow_decider.pl
+++ b/bin/sanger_workflow_decider.pl
@@ -47,14 +47,14 @@ my ($cluster_information, $running_sample_ids, $failed_samples, $completed_sampl
 
 #my $failed_db = Decider::Database->failed_connect();
 
-print "CLUSTER INFO:\n";
-print Dumper($cluster_information);
-print "RUNNING SAMPLES:\n";
-print Dumper($running_sample_ids);
-print "FAILED SAMPLES:\n";
-print Dumper($failed_samples);
-print "COMPLETED SAMPLES:\n";
-print Dumper($completed_samples);
+#print "CLUSTER INFO:\n";
+#print Dumper($cluster_information);
+#print "RUNNING SAMPLES:\n";
+#print Dumper($running_sample_ids);
+#print "FAILED SAMPLES:\n";
+#print Dumper($failed_samples);
+#print "COMPLETED SAMPLES:\n";
+#print Dumper($completed_samples);
 
 say 'Reading in GNOS Sample Information';
 my $gnos_info = GNOS::SampleInformation->new();
@@ -70,18 +70,18 @@ my $sample_information = $gnos_info->get( $ARGV{'--working-dir'},
 					  $whitelist,
 					  $blacklist);
 
-print "DUMPING SAMPLE INFO:\n";
-print Dumper($sample_information);
+#print "DUMPING SAMPLE INFO:\n";
+#print Dumper($sample_information);
 
 if (defined($ARGV{'--local-status-cache'})) {
   say 'Combining Previous Results with Local Cache File';
   ($running_sample_ids, $failed_samples, $completed_samples) = SeqWare::Cluster->combine_local_data($running_sample_ids, $failed_samples, $completed_samples, $ARGV{'--local-status-cache'}, $sample_information);
-  print "RUNNING SAMPLES:\n";
-  print Dumper($running_sample_ids);
-  print "FAILED SAMPLES:\n";
-  print Dumper($failed_samples);
-  print "COMPLETED SAMPLES:\n";
-  print Dumper($completed_samples);
+  #print "RUNNING SAMPLES:\n";
+  #print Dumper($running_sample_ids);
+  #print "FAILED SAMPLES:\n";
+  #print Dumper($failed_samples);
+  #print "COMPLETED SAMPLES:\n";
+  #print Dumper($completed_samples);
 }
 
 say 'Scheduling Samples';

--- a/bin/sanger_workflow_decider.pl
+++ b/bin/sanger_workflow_decider.pl
@@ -84,8 +84,6 @@ if (defined($ARGV{'--local-status-cache'})) {
   print Dumper($completed_samples);
 }
 
-die;
-
 say 'Scheduling Samples';
 my $scheduler = SeqWare::Schedule::Sanger->new();
 my %args = %ARGV;

--- a/bin/sanger_workflow_decider.pl
+++ b/bin/sanger_workflow_decider.pl
@@ -55,7 +55,6 @@ print "FAILED SAMPLES:\n";
 print Dumper($failed_samples);
 print "COMPLETED SAMPLES:\n";
 print Dumper($completed_samples);
-die;
 
 say 'Reading in GNOS Sample Information';
 my $gnos_info = GNOS::SampleInformation->new();
@@ -71,12 +70,21 @@ my $sample_information = $gnos_info->get( $ARGV{'--working-dir'},
 					  $whitelist,
 					  $blacklist);
 
-#print Dumper($sample_information);
+print "DUMPING SAMPLE INFO:\n";
+print Dumper($sample_information);
 
 if (defined($ARGV{'--local-status-cache'})) {
   say 'Combining Previous Results with Local Cache File';
   ($running_sample_ids, $failed_samples, $completed_samples) = SeqWare::Cluster->combine_local_data($running_sample_ids, $failed_samples, $completed_samples, $ARGV{'--local-status-cache'}, $sample_information);
+  print "RUNNING SAMPLES:\n";
+  print Dumper($running_sample_ids);
+  print "FAILED SAMPLES:\n";
+  print Dumper($failed_samples);
+  print "COMPLETED SAMPLES:\n";
+  print Dumper($completed_samples);
 }
+
+die;
 
 say 'Scheduling Samples';
 my $scheduler = SeqWare::Schedule::Sanger->new();

--- a/lib/SeqWare/Cluster.pm
+++ b/lib/SeqWare/Cluster.pm
@@ -117,19 +117,19 @@ sub cluster_seqware_information {
        $cluster_info,
        $samples_status_ids);
        my $cluster_num = 0;
+
     foreach my $cluster_name (keys %{$clusters}) {
         my $cluster_metadata = $clusters->{$cluster_name};
         $cluster_num++;
-        print "CLUSTER METADATA: $cluster_num NAME: $cluster_name\n";
-        print Dumper($cluster_metadata);
+        #print "CLUSTER METADATA: $cluster_num NAME: $cluster_name\n";
+        #print Dumper($cluster_metadata);
+
         ($cluster_info, $samples_status_ids)
             = seqware_information( $report_file,
                                    $cluster_name,
                                    $cluster_metadata,
                                    $run_workflow_version,
                                    $failure_reports_dir);
-
-        # LEFT OFF HERE: need to pass back the structure for failed workflows, parse it, and write out a report for it
 
         foreach my $cluster (keys %{$cluster_info}) {
            $cluster_information{$cluster} = $cluster_info->{$cluster};

--- a/lib/SeqWare/Cluster.pm
+++ b/lib/SeqWare/Cluster.pm
@@ -120,7 +120,7 @@ sub cluster_seqware_information {
     foreach my $cluster_name (keys %{$clusters}) {
         my $cluster_metadata = $clusters->{$cluster_name};
         $cluster_num++;
-        print "CLUSTER METADATA: \n";
+        print "CLUSTER METADATA: $cluster_num\n";
         print Dumper($cluster_metadata);
         ($cluster_info, $samples_status_ids)
             = seqware_information( $report_file,

--- a/lib/SeqWare/Cluster.pm
+++ b/lib/SeqWare/Cluster.pm
@@ -120,7 +120,7 @@ sub cluster_seqware_information {
     foreach my $cluster_name (keys %{$clusters}) {
         my $cluster_metadata = $clusters->{$cluster_name};
         $cluster_num++;
-        print "CLUSTER METADATA: $cluster_num\n";
+        print "CLUSTER METADATA: $cluster_num NAME: $cluster_name\n";
         print Dumper($cluster_metadata);
         ($cluster_info, $samples_status_ids)
             = seqware_information( $report_file,

--- a/lib/SeqWare/Cluster.pm
+++ b/lib/SeqWare/Cluster.pm
@@ -116,9 +116,12 @@ sub cluster_seqware_information {
        %completed_samples,
        $cluster_info,
        $samples_status_ids);
+       my $cluster_num = 0;
     foreach my $cluster_name (keys %{$clusters}) {
         my $cluster_metadata = $clusters->{$cluster_name};
-        #print Dumper($cluster_metadata);
+        $cluster_num++;
+        print "CLUSTER METADATA: \n";
+        print Dumper($cluster_metadata);
         ($cluster_info, $samples_status_ids)
             = seqware_information( $report_file,
                                    $cluster_name,

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -630,9 +630,14 @@ sub previously_failed_running_or_completed {
     my ($donor, $running_samples) = @_;
     print Dumper($donor);
     my @want_to_run;
-    foreach my $key (keys %{$donor->{analysis_ids}}) {
+
+    foreach my $key (keys %{$donor->{normal}}) {
       push @want_to_run, $donor->{analysis_ids}{$key};
     }
+    foreach my $key (keys %{$donor->{tumor}}) {
+      push @want_to_run, $donor->{analysis_ids}{$key};
+    }
+
     my $want_to_run_str = join (",", sort(@want_to_run));
     my $previously_run = 0;
     # now check

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -570,7 +570,8 @@ sub schedule_donor {
     $donor->{normal} = \%normal;
     $donor->{tumor}  = \%tumor;
 
-    say "\nABOUT TO SCHEDULE";
+    say "\nABOUT TO SCHEDULE $donor_id";
+    print "\nABOUT TO SCHEDULE $donor_id";
 
     $self->schedule_workflow( $donor,
 			      $seqware_settings_file,
@@ -638,6 +639,9 @@ sub previously_failed_running_or_completed {
      print "RUNNING: $key $want_to_run_str\n";
    }
    print "PREVIOUSLY RUN:$previously_run\n";
+
+   die;
+
    return($previously_run);
 }
 

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -608,17 +608,17 @@ sub should_be_scheduled {
     my $running_samples = shift;
     my $donor = shift;
 
-    if ($skip_scheduling) {
-        say $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING";
-        return 1;
-    }
-
-
     #return 1;
     # LEFT OFF WITH: need to combine the schedule function with previously_failed... Sheldon, is this what was intended?
     my $prev_failed_running_complete = $self->previously_failed_running_or_completed($donor, $running_samples);
     if ($prev_failed_running_complete) { say $report_file "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED"; }
     else { say $report_file "\t\tCONCLUSION: SCHEDULING FOR VCF"; }
+
+    if ($skip_scheduling) {
+      say $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING";
+      return 1;
+    }
+
     return (!$prev_failed_running_complete);
 }
 

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -628,7 +628,7 @@ sub should_be_scheduled {
 sub previously_failed_running_or_completed {
     my $self = shift;
     my ($donor, $running_samples) = @_;
-    print Dumper($donor);
+    #print Dumper($donor);
     my @want_to_run;
 
     foreach my $key (keys %{$donor->{normal}}) {
@@ -643,7 +643,7 @@ sub previously_failed_running_or_completed {
     # now check
     foreach my $key (keys %{$running_samples}) {
       if ($key eq $want_to_run_str) { $previously_run = 1; }
-      print "RUNNING SAMPLE: $key WANT TO RUN: $want_to_run_str PREVIOUSLY RUN BOOL: $previously_run\n";
+      #print "RUNNING SAMPLE: $key WANT TO RUN: $want_to_run_str PREVIOUSLY RUN BOOL: $previously_run\n";
     }
     print "PREVIOUSLY RUN:$previously_run\n";
 

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -608,41 +608,43 @@ sub should_be_scheduled {
     my $running_samples = shift;
     my $donor = shift;
 
-    #return 1;
-    # LEFT OFF WITH: need to combine the schedule function with previously_failed... Sheldon, is this what was intended?
+    # running_samples here actually contains running, failed, and completed
     my $prev_failed_running_complete = $self->previously_failed_running_or_completed($donor, $running_samples);
-    if ($prev_failed_running_complete) { say $report_file "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED"; }
-    else { say $report_file "\t\tCONCLUSION: SCHEDULING FOR VCF"; }
-
-    if ($skip_scheduling) {
-      say $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING";
-      return 1;
+    if ($prev_failed_running_complete) {
+      say $report_file "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED";
+      print $report_file "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED\n";
+      return(0);
+    } elsif ($skip_scheduling) {
+      say $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING SINCE SKIP-SCHEDULING SELECTED";
+      print $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING SINCE SKIP-SCHEDULING SELECTED\n";
+      return(0);
+    } else {
+      say $report_file "\t\tCONCLUSION: SCHEDULING FOR VCF";
+      print $report_file "\t\tCONCLUSION: SCHEDULING FOR VCF\n";
+      return(1);
     }
-
-    return (!$prev_failed_running_complete);
 }
 
-# TODO: combine with the schedule method below, is the scheduled method even being used currently?
 sub previously_failed_running_or_completed {
     my $self = shift;
-    my ($donor,
-	$running_samples) = @_;
-   my @want_to_run;
-   foreach my $key (keys %{$donor->{analysis_ids}}) {
-     push @want_to_run, $donor->{analysis_ids}{$key};
-   }
-   my $want_to_run_str = join (",", sort(@want_to_run));
-   my $previously_run = 0;
-   # now check
-   foreach my $key (keys %{$running_samples}) {
-     if ($key eq $want_to_run_str) { $previously_run = 1; }
-     print "RUNNING: $key $want_to_run_str\n";
-   }
-   print "PREVIOUSLY RUN:$previously_run\n";
+    my ($donor, $running_samples) = @_;
+    print Dumper($donor);
+    my @want_to_run;
+    foreach my $key (keys %{$donor->{analysis_ids}}) {
+      push @want_to_run, $donor->{analysis_ids}{$key};
+    }
+    my $want_to_run_str = join (",", sort(@want_to_run));
+    my $previously_run = 0;
+    # now check
+    foreach my $key (keys %{$running_samples}) {
+      if ($key eq $want_to_run_str) { $previously_run = 1; }
+      print "RUNNING SAMPLE: $key WANT TO RUN: $want_to_run_str PREVIOUSLY RUN BOOL: $previously_run\n";
+    }
+    print "PREVIOUSLY RUN:$previously_run\n";
 
-   die;
+die;
 
-   return($previously_run);
+    return($previously_run);
 }
 
 sub scheduled {

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -333,7 +333,7 @@ sub schedule_donor {
 	) = @_;
 
     say "GOING TO SCHEDULE";
-    say $report_file "DONOR/PARTICIPANT: $donor_id\n";
+    say $report_file "\nDONOR/PARTICIPANT: $donor_id\n";
 
     my @sample_ids = keys %{$donor_information};
     my @samples;

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -647,8 +647,6 @@ sub previously_failed_running_or_completed {
     }
     print "PREVIOUSLY RUN:$previously_run\n";
 
-die;
-
     return($previously_run);
 }
 

--- a/lib/SeqWare/Schedule.pm
+++ b/lib/SeqWare/Schedule.pm
@@ -612,15 +612,15 @@ sub should_be_scheduled {
     my $prev_failed_running_complete = $self->previously_failed_running_or_completed($donor, $running_samples);
     if ($prev_failed_running_complete) {
       say $report_file "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED";
-      print $report_file "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED\n";
+      #print "\t\t\tCONCLUSION: NOT SCHEDULING FOR VCF, PREVIOUSLY FAILED, RUNNING, OR COMPLETED\n";
       return(0);
     } elsif ($skip_scheduling) {
       say $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING SINCE SKIP-SCHEDULING SELECTED";
-      print $report_file "\t\tCONCLUSION: SKIPPING SCHEDULING SINCE SKIP-SCHEDULING SELECTED\n";
+      #print "\t\tCONCLUSION: SKIPPING SCHEDULING SINCE SKIP-SCHEDULING SELECTED\n";
       return(0);
     } else {
       say $report_file "\t\tCONCLUSION: SCHEDULING FOR VCF";
-      print $report_file "\t\tCONCLUSION: SCHEDULING FOR VCF\n";
+      #print "\t\tCONCLUSION: SCHEDULING FOR VCF\n";
       return(1);
     }
 }


### PR DESCRIPTION
So the problem boils down to two major issues 1) seems like the option for skip scheduling wasn't returning 0 when it should so it wasn't actually skipping.  And 2), the major issue, for donors with specimens that had multiple, duplicate alignments the system that checked to see if it previously ran was not working.  The ini creation and recording aliquoit IDs of what was run worked.  But the code that checked this against what was to be scheduled did not since it included duplicate alignments.  So what is running, previously ran, or previously failed _never_ matched the donor about to be launched.  And the same donor was launched over, and over, and over again.

You can see in the screen shot below how the extra analysis event was causing the previously ran vs. what's about to run to never match.

![problem](https://cloud.githubusercontent.com/assets/1730584/5895221/cb80e610-a4e6-11e4-841e-b8d888e87988.png)
